### PR TITLE
Container display as relative

### DIFF
--- a/examples/www/index.html
+++ b/examples/www/index.html
@@ -15,6 +15,7 @@
 			}
 			/* style the three.js container however your want */
 			#container {
+				position: relative;
 				height: 100%;
 				width: 100%;
 			}


### PR DESCRIPTION
changed container display to relative so that the progress bar would show up in the container when it's style to be fixed width/height.